### PR TITLE
Update layout.html

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -33,6 +33,5 @@ pathto("_static/logo.jpg", 1) }}" border="0"/></a></div>
 {% endblock %}
 
 {# put the sidebar before the body #}
-{% block sidebar1 %}{{ sidebar() }}{% endblock %}
-{% block sidebar2 %}
-{% endblock %}
+{% block sidebar2 %}{{ sidebar() }}{% endblock %}
+{% block sidebar1 %}{% endblock %}


### PR DESCRIPTION
fixed custom sphinxdoc layout error, sidebar1 appears before the document and is empty by default, sidebar2 after the document and contains the default sidebar.